### PR TITLE
feat: introduce `UUPSExtUpgradeable` base contract

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { UUPSExtUpgradeable } from "./base/UUPSExtUpgradeable.sol";
 
 import { BlocklistableUpgradeable } from "./base/BlocklistableUpgradeable.sol";
 import { PausableExtUpgradeable } from "./base/PausableExtUpgradeable.sol";
@@ -26,7 +26,7 @@ contract CardPaymentProcessor is
     BlocklistableUpgradeable,
     PausableExtUpgradeable,
     RescuableUpgradeable,
-    UUPSUpgradeable,
+    UUPSExtUpgradeable,
     ICardPaymentProcessor,
     ICardPaymentCashback,
     Versionable
@@ -86,6 +86,9 @@ contract CardPaymentProcessor is
 
     /// @dev The zero payer address has been passed as a function argument.
     error AccountZeroAddress();
+
+    /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
+    error CardPaymentProcessor_ImplementationAddressInvalid();
 
     /// @dev The cashback operations are already enabled.
     error CashbackAlreadyEnabled();
@@ -636,6 +639,10 @@ contract CardPaymentProcessor is
     function getAccountCashbackState(address account) external view returns (AccountCashbackState memory) {
         return _accountCashbackStates[account];
     }
+    // ------------------ Pure functions -------------------------- //
+
+     /// @inheritdoc ICardPaymentProcessor
+    function proveCardPaymentProcessor() external pure {}
 
     // ------------------ Internal functions ---------------------- //
 
@@ -1355,10 +1362,14 @@ contract CardPaymentProcessor is
         return eventFlags;
     }
 
-    /// @dev The upgrade authorization function for UUPSProxy.
-    function _authorizeUpgrade(address newImplementation) internal view override {
-        newImplementation; // Suppresses a compiler warning about the unused variable
-        _checkRole(OWNER_ROLE);
+    /**
+     * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
+        try ICardPaymentProcessor(newImplementation).proveCardPaymentProcessor() {} catch {
+            revert CardPaymentProcessor_ImplementationAddressInvalid();
+        }
     }
 
     // ------------------ Service functions ----------------------- //

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -88,7 +88,7 @@ contract CardPaymentProcessor is
     error AccountZeroAddress();
 
     /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
-    error CardPaymentProcessor_ImplementationAddressInvalid();
+    error ImplementationAddressInvalid();
 
     /// @dev The cashback operations are already enabled.
     error CashbackAlreadyEnabled();
@@ -1368,7 +1368,7 @@ contract CardPaymentProcessor is
      */
     function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
         try ICardPaymentProcessor(newImplementation).proveCardPaymentProcessor() {} catch {
-            revert CardPaymentProcessor_ImplementationAddressInvalid();
+            revert ImplementationAddressInvalid();
         }
     }
 

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -87,9 +87,6 @@ contract CardPaymentProcessor is
     /// @dev The zero payer address has been passed as a function argument.
     error AccountZeroAddress();
 
-    /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
-    error ImplementationAddressInvalid();
-
     /// @dev The cashback operations are already enabled.
     error CashbackAlreadyEnabled();
 
@@ -116,6 +113,9 @@ contract CardPaymentProcessor is
 
     /// @dev A new cash-out account is the same as the previously set one.
     error CashOutAccountUnchanged();
+
+    /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
+    error ImplementationAddressInvalid();
 
     /// @dev The requested confirmation amount does not meet the requirements.
     error InappropriateConfirmationAmount();

--- a/contracts/base/UUPSExtUpgradeable.sol
+++ b/contracts/base/UUPSExtUpgradeable.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradeable base contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev Extends the OpenZeppelin's {UUPSUpgradeable} contract by adding additional checks for
+ * the new implementation address.
+ *
+ * This contract is used through inheritance. It introduces the virtual `_validateUpgrade()` function that must be
+ * implemented in the parent contract.
+ */
+abstract contract UUPSExtUpgradeable is UUPSUpgradeable {
+    // ------------------ Errors ---------------------------------- //
+
+    /// @dev Thrown if the provided new implementation address is not a contract.
+    error UUPSExtUpgradeable_ImplementationAddressNotContract();
+
+    /// @dev Thrown if the provided new implementation contract address is zero.
+    error UUPSExtUpgradeable_ImplementationAddressZero();
+
+    // ------------------ Internal functions ---------------------- //
+
+    /**
+     * @dev The upgrade authorization function for UUPSProxy.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override {
+        if (newImplementation == address(0)) {
+            revert UUPSExtUpgradeable_ImplementationAddressZero();
+        }
+
+        if (newImplementation.code.length == 0) {
+            revert UUPSExtUpgradeable_ImplementationAddressNotContract();
+        }
+
+        _validateUpgrade(newImplementation);
+    }
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual;
+}

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(2, 0, 0);
+        return Version(2, 1, 0);
     }
 }

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -455,4 +455,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
 
     /// @dev Returns statistics of all payments.
     function getPaymentStatistics() external view returns (PaymentStatistics memory);
+
+    /// @dev Proves the contract is the card payment processor one. A marker function.
+    function proveCardPaymentProcessor() external pure;
 }

--- a/contracts/mocks/base/UUPSExtUpgradableMock.sol
+++ b/contracts/mocks/base/UUPSExtUpgradableMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSExtUpgradeable } from "../../base/UUPSExtUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradableMock contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev An implementation of the {UUPSExtUpgradable} contract for test purposes.
+ */
+contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
+    /// @dev Emitted when the internal `_validateUpgrade()` function is called with the parameters of the function.
+    event MockValidateUpgradeCall(address newImplementation);
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual override {
+        emit MockValidateUpgradeCall(newImplementation);
+    }
+}

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1782,7 +1782,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller is not the owner", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
 
-      await expect(connect(cardPaymentProcessor, user1).upgradeToAndCall(user1.address, "0x"))
+      await expect(connect(cardPaymentProcessor, user1).upgradeToAndCall(cardPaymentProcessor, "0x"))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT);
     });
   });
@@ -1796,7 +1796,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     it("Is reverted if the caller is not the owner", async () => {
       const { cardPaymentProcessor } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
 
-      await expect(connect(cardPaymentProcessor, user1).upgradeTo(user1.address))
+      await expect(connect(cardPaymentProcessor, user1).upgradeTo(cardPaymentProcessor))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT);
     });
   });

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1551,7 +1551,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const CASHBACK_RATE_ZERO = 0;
   const EXPECTED_VERSION: Version = {
     major: 2,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1559,7 +1559,6 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CONTRACT_IS_PAUSED = "EnforcedPause";
   const REVERT_ERROR_IF_ERC20_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20InsufficientBalance";
   const REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT = "AccessControlUnauthorizedAccount";
-  const REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
 
   const REVERT_ERROR_IF_ACCOUNT_ZERO_ADDRESS = "AccountZeroAddress";
   const REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED = "CashbackAlreadyEnabled";
@@ -1571,6 +1570,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CASHBACK_RATE_UNCHANGED = "CashbackRateUnchanged";
   const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_NOT_CONFIGURED = "CashOutAccountNotConfigured";
   const REVERT_ERROR_IF_CASH_OUT_ACCOUNT_UNCHANGED = "CashOutAccountUnchanged";
+  const REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
   const REVERT_ERROR_IF_INAPPROPRIATE_CONFIRMATION_AMOUNT = "InappropriateConfirmationAmount";
   const REVERT_ERROR_IF_INAPPROPRIATE_REFUNDING_AMOUNT = "InappropriateRefundingAmount";
   const REVERT_ERROR_IF_INAPPROPRIATE_PAYMENT_STATUS = "InappropriatePaymentStatus";

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1559,6 +1559,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const REVERT_ERROR_IF_CONTRACT_IS_PAUSED = "EnforcedPause";
   const REVERT_ERROR_IF_ERC20_TOKEN_TRANSFER_AMOUNT_EXCEEDS_BALANCE = "ERC20InsufficientBalance";
   const REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT = "AccessControlUnauthorizedAccount";
+  const REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
 
   const REVERT_ERROR_IF_ACCOUNT_ZERO_ADDRESS = "AccountZeroAddress";
   const REVERT_ERROR_IF_CASHBACK_ALREADY_ENABLED = "CashbackAlreadyEnabled";
@@ -1785,6 +1786,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       await expect(connect(cardPaymentProcessor, user1).upgradeToAndCall(cardPaymentProcessor, "0x"))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT);
     });
+
+    it("Is reverted if the provided implementation address is not a card payment processor contract", async () => {
+      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+
+      await expect(cardPaymentProcessor.upgradeToAndCall(getAddress(tokenMock), "0x"))
+        .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID);
+    });
   });
 
   describe("Function 'upgradeTo()'", async () => {
@@ -1798,6 +1806,13 @@ describe("Contract 'CardPaymentProcessor'", async () => {
 
       await expect(connect(cardPaymentProcessor, user1).upgradeTo(cardPaymentProcessor))
         .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_UNAUTHORIZED_ACCOUNT);
+    });
+
+    it("Is reverted if the provided implementation address is not a card payment processor contract", async () => {
+      const { cardPaymentProcessor, tokenMock } = await setUpFixture(deployTokenMockAndCardPaymentProcessor);
+
+      await expect(cardPaymentProcessor.upgradeTo(getAddress(tokenMock)))
+        .to.be.revertedWithCustomError(cardPaymentProcessor, REVERT_ERROR_IF_IMPLEMENTATION_ADDRESS_INVALID);
     });
   });
 

--- a/test/base/UUPSExtUbgradable.test.ts
+++ b/test/base/UUPSExtUbgradable.test.ts
@@ -1,0 +1,70 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { connect } from "../../test-utils/eth";
+
+const ADDRESS_ZERO = ethers.ZeroAddress;
+
+async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contracts 'UUPSExtUpgradeable'", async () => {
+  // Errors of the lib contracts
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT = "UUPSExtUpgradeable_ImplementationAddressNotContract";
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO = "UUPSExtUpgradeable_ImplementationAddressZero";
+
+  // Events of the contracts under test
+  const EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL = "MockValidateUpgradeCall";
+
+  let uupsExtensionFactory: ContractFactory;
+  let deployer: HardhatEthersSigner;
+
+  before(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // The contract factory with the explicitly specified deployer account
+    uupsExtensionFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+    uupsExtensionFactory = uupsExtensionFactory.connect(deployer);
+  });
+
+  async function deployContract(): Promise<{ uupsExtension: Contract }> {
+    let uupsExtension: Contract = await upgrades.deployProxy(uupsExtensionFactory, [], { initializer: false });
+    await uupsExtension.waitForDeployment();
+    uupsExtension = connect(uupsExtension, deployer); // Explicitly specifying the initial account
+
+    return { uupsExtension };
+  }
+
+  describe("Function 'upgradeToAndCall()'", async () => {
+    it("Executes as expected", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+
+      const newImplementation = await uupsExtensionFactory.deploy();
+      await newImplementation.waitForDeployment();
+      const newImplementationAddress = await newImplementation.getAddress();
+
+      await expect(uupsExtension.upgradeToAndCall(newImplementationAddress, "0x"))
+        .to.emit(uupsExtension, EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL)
+        .withArgs(newImplementationAddress);
+    });
+
+    it("Is reverted if the new implementation address is zero", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(ADDRESS_ZERO, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO);
+    });
+
+    it("Is reverted if the new implementation address is not a contract", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(deployer.address, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT);
+    });
+  });
+});


### PR DESCRIPTION
## Main changes

1. The new `UUPSExtUpgradeable` contract has been introduced for internal usage through inheritance.
2. The new contract provides additional checks during the upgrade, making the procedure safer.
3. A new marker function named `proveCardPaymentProcessor()` has been added to the `CardPaymentProcessor` contract for use in conjunction with the new `UUPSExtUpgradeable` contract. When upgrading, that function ensures that the new implementation of the contract is compatible.

## Versioning 

The version of the `CardPaymentProcessor` contract has been changed: `2.0.0` => `2.1.0`.

## Test coverage

New functionality was fully covered by tests.