### PR TITLE
feat: add the cashback cap preview function to CashbackDistributor

### DIFF
--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -413,14 +413,23 @@ contract CashbackDistributor is
         return _totalCashbackByTokenAndRecipient[token][recipient];
     }
 
+    /**
+     * @dev See {ICashbackDistributor-getCashbackSinceLastReset}.
+     */
     function getCashbackSinceLastReset(address token, address recipient) external view returns (uint256) {
         return _cashbackSinceLastReset[token][recipient];
     }
 
+    /**
+     * @dev See {ICashbackDistributor-getCashbackLastTimeReset}.
+     */
     function getCashbackLastTimeReset(address token, address recipient) external view returns (uint256) {
         return _cashbackLastTimeReset[token][recipient];
     }
 
+    /**
+     * @dev See {ICashbackDistributor-previewCashbackCap}.
+     */
     function previewCashbackCap(
         address token,
         address recipient

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -458,8 +458,10 @@ contract CashbackDistributor is
         address recipient,
         uint256 amount
     ) internal returns (bool accepted, uint256 acceptedAmount) {
-        (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod, uint256 isPeriodReset) =
-                        _previewCashbackCap(token, recipient);
+        (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod, uint256 isPeriodReset) = _previewCashbackCap(
+            token,
+            recipient
+        );
         if (isPeriodReset != 0) {
             _cashbackLastTimeReset[token][recipient] = cashbackPeriodStart;
         }

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -421,23 +421,44 @@ contract CashbackDistributor is
         return _cashbackLastTimeReset[token][recipient];
     }
 
+    function previewCashbackCap(
+        address token,
+        address recipient
+    ) external view returns (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod) {
+        (cashbackPeriodStart, overallCashbackForPeriod, ) = _previewCashbackCap(token, recipient);
+    }
+
+    function _previewCashbackCap(
+        address token,
+        address recipient
+    ) internal view returns (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod, uint256 isPeriodReset) {
+        overallCashbackForPeriod = 0;
+        isPeriodReset = 0;
+        cashbackPeriodStart = _cashbackLastTimeReset[token][recipient];
+
+        if (block.timestamp - cashbackPeriodStart > CASHBACK_RESET_PERIOD) {
+            cashbackPeriodStart = block.timestamp;
+            isPeriodReset = 1;
+        } else {
+            overallCashbackForPeriod = _cashbackSinceLastReset[token][recipient];
+        }
+    }
+
     function _updateCashbackCap(
         address token,
         address recipient,
         uint256 amount
     ) internal returns (bool accepted, uint256 acceptedAmount) {
-        uint256 overallCashback = 0;
-
-        if (block.timestamp - _cashbackLastTimeReset[token][recipient] > CASHBACK_RESET_PERIOD) {
-            _cashbackLastTimeReset[token][recipient] = block.timestamp;
-        } else {
-            overallCashback = _cashbackSinceLastReset[token][recipient];
+        (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod, uint256 isPeriodReset) =
+                        _previewCashbackCap(token, recipient);
+        if (isPeriodReset != 0) {
+            _cashbackLastTimeReset[token][recipient] = cashbackPeriodStart;
         }
 
-        if (overallCashback < MAX_CASHBACK_FOR_PERIOD) {
-            uint256 leftAmount = MAX_CASHBACK_FOR_PERIOD - overallCashback;
+        if (overallCashbackForPeriod < MAX_CASHBACK_FOR_PERIOD) {
+            uint256 leftAmount = MAX_CASHBACK_FOR_PERIOD - overallCashbackForPeriod;
             acceptedAmount = leftAmount >= amount ? amount : leftAmount;
-            _cashbackSinceLastReset[token][recipient] = overallCashback + acceptedAmount;
+            _cashbackSinceLastReset[token][recipient] = overallCashbackForPeriod + acceptedAmount;
             accepted = true;
         }
     }

--- a/contracts/CashbackDistributorStorage.sol
+++ b/contracts/CashbackDistributorStorage.sol
@@ -38,12 +38,16 @@ abstract contract CashbackDistributorStorageV1 is ICashbackDistributorTypes {
  * @title CashbackDistributor storage version 2
  */
 abstract contract CashbackDistributorStorageV2 {
+    /// @dev The cashback periodical cap reset period.
     uint256 public constant CASHBACK_RESET_PERIOD = 30 days;
 
+    /// @dev The maximum amount of cashback for a period.
     uint256 public constant MAX_CASHBACK_FOR_PERIOD = 300 * 10 ** 6;
 
+    /// @dev The mapping of the last time the cashback periodical cap was reset for a token and a recipient.
     mapping(address => mapping(address => uint256)) internal _cashbackLastTimeReset;
 
+    /// @dev The mapping of the total amount of cashback within the current cap period for a token and a recipient.
     mapping(address => mapping(address => uint256)) internal _cashbackSinceLastReset;
 }
 

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 0, 0);
+        return Version(1, 1, 0);
     }
 }

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -324,4 +324,30 @@ interface ICashbackDistributor is ICashbackDistributorTypes {
      * @param recipient The recipient address of the cashback operations to define the returned total amount.
      */
     function getTotalCashbackByTokenAndRecipient(address token, address recipient) external view returns (uint256);
+
+    /**
+     * @dev Returns the total amount of all the success cashback operations since the last reset of the periodical cap.
+     * @param token The token contract address of the cashback operations to define the returned total amount.
+     * @param recipient The recipient address of the cashback operations to define the returned total amount.
+     */
+    function getCashbackSinceLastReset(address token, address recipient) external view returns (uint256);
+
+    /**
+     * @dev Returns the last time the cashback periodical cap was reset for a token and a recipient.
+     * @param token The token contract address of the cashback operations to define the returned last time.
+     * @param recipient The recipient address of the cashback operations to define the returned last time.
+     */
+    function getCashbackLastTimeReset(address token, address recipient) external view returns (uint256);
+
+    /**
+     * @dev Determines a preview of the cashback cap state for a token and a recipient at the current block timestamp.
+     * @param token The token contract address of the cashback operations to define the returned cashback cap state.
+     * @param recipient The recipient address of the cashback operations to define the returned cashback cap state.
+     * @return cashbackPeriodStart The start time of the current cashback cap period.
+     * @return overallCashbackForPeriod The total amount of cashback within the current cashback cap period.
+     */
+    function previewCashbackCap(
+        address token,
+        address recipient
+    ) external view returns (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod);
 }

--- a/contracts/mocks/CashbackDistributorMock.sol
+++ b/contracts/mocks/CashbackDistributorMock.sol
@@ -172,7 +172,7 @@ contract CashbackDistributorMock is ICashbackDistributor {
         return 0;
     }
 
-   /**
+    /**
      * @dev See {ICashbackDistributor-getCashbackSinceLastReset}.
      *
      * Just a stub for testing. Always returns zero.

--- a/contracts/mocks/CashbackDistributorMock.sol
+++ b/contracts/mocks/CashbackDistributorMock.sol
@@ -89,6 +89,9 @@ contract CashbackDistributorMock is ICashbackDistributor {
         getCashbackNonces(bytes32(0), 0, 0);
         getTotalCashbackByTokenAndExternalId(address(0), bytes32(0));
         getTotalCashbackByTokenAndRecipient(address(0), address(0));
+        getCashbackSinceLastReset(address(0), address(0));
+        getCashbackLastTimeReset(address(0), address(0));
+        previewCashbackCap(address(0), address(0));
         enable();
         disable();
     }
@@ -167,6 +170,43 @@ contract CashbackDistributorMock is ICashbackDistributor {
         token;
         recipient;
         return 0;
+    }
+
+   /**
+     * @dev See {ICashbackDistributor-getCashbackSinceLastReset}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getCashbackSinceLastReset(address token, address recipient) public pure returns (uint256) {
+        token;
+        recipient;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-getCashbackLastTimeReset}.
+     *
+     * Just a stub for testing. Always returns zero.
+     */
+    function getCashbackLastTimeReset(address token, address recipient) public pure returns (uint256) {
+        token;
+        recipient;
+        return 0;
+    }
+
+    /**
+     * @dev See {ICashbackDistributor-previewCashbackCap}.
+     *
+     * Just a stub for testing. Always returns zeros.
+     */
+    function previewCashbackCap(
+        address token,
+        address recipient
+    ) public pure returns (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod) {
+        token;
+        recipient;
+        cashbackPeriodStart = 0;
+        overallCashbackForPeriod = 0;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brlc-periphery",
+  "name": "brlc-card-payment-processor",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1914,7 +1914,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const CASHBACK_NONCE = 111222333;
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -186,7 +186,7 @@ describe("Contract 'CashbackDistributor'", async () => {
   const MAX_CASHBACK_FOR_PERIOD = 300 * 10 ** 6;
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 0,
+    minor: 1,
     patch: 0
   };
 

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -1276,17 +1276,17 @@ describe("Contract 'CashbackDistributor'", async () => {
         expectedLastTimeReset: number;
         expectedCashbackSum: number;
       }) {
-        expect(
-          await cashbackDistributor.getCashbackLastTimeReset(getAddress(tokenMock), recipient.address)
-        ).to.equal(
+        expect(await cashbackDistributor.getCashbackLastTimeReset(getAddress(tokenMock), recipient.address)).to.equal(
           props.expectedLastTimeReset
         );
 
-        expect(
-          await cashbackDistributor.getCashbackSinceLastReset(getAddress(tokenMock), recipient.address)
-        ).to.equal(
+        expect(await cashbackDistributor.getCashbackSinceLastReset(getAddress(tokenMock), recipient.address)).to.equal(
           props.expectedCashbackSum
         );
+
+        expect(
+          await cashbackDistributor.previewCashbackCap(getAddress(tokenMock), recipient.address)
+        ).to.deep.equal([props.expectedLastTimeReset, props.expectedCashbackSum]);
       }
 
       // Reset the cashback sum for period cashback cap control and check the cap-related values.
@@ -1344,6 +1344,13 @@ describe("Contract 'CashbackDistributor'", async () => {
 
       // Shift next block time for a period of cap checking.
       await increaseBlockTimestamp(CASHBACK_RESET_PERIOD + 1);
+
+      // Check that the cap state preview function returns expected values when a new cap period starts
+      const timestampBefore = (await ethers.provider.getBlock("latest"))?.timestamp ?? 0;
+      const actualPreview = await cashbackDistributor.previewCashbackCap(getAddress(tokenMock), recipient.address);
+      const timestampAfter = (await ethers.provider.getBlock("latest"))?.timestamp ?? 0;
+      expect(actualPreview[0]).to.be.within(timestampBefore, timestampAfter);
+      expect(actualPreview[1]).to.equal(0);
 
       // Check that next cashback sending executes successfully due to the cap period resets
       cashbacks[4].sentAmount = cashbacks[4].requestedAmount;


### PR DESCRIPTION
## Main changes
1. The new function `previewCashbackCap()` has been added to the `CashbackDistributor` smart contract. The new function determines the sate of the periodical cashback cap at the current block timestamp (at the call moment):

    <details>
    
    <summary>The definition of the new function </summary>
    
    ```solidity
    /**
     * @dev Determines a preview of the cashback cap state for a token and a recipient at the current block timestamp.
     * @param token The token contract address of the cashback operations to define the returned cashback cap state.
     * @param recipient The recipient address of the cashback operations to define the returned cashback cap state.
     * @return cashbackPeriodStart The start time of the current cashback cap period.
     * @return overallCashbackForPeriod The total amount of cashback within the current cashback cap period.
     */
    function previewCashbackCap(
        address token,
        address recipient
    ) external view returns (uint256 cashbackPeriodStart, uint256 overallCashbackForPeriod);
    ```
    
    </details>

2. If the previous reset of the cashback cap occurred more than a period ago, then the values returned by the new function will be: 
    * `cashbackPeriodStart`: equals to the block timestamp at the call moment.
    * `overallCashbackForPeriod`: equals zero.
    
## Versioning

The smart contracts version has been updated to `v1.1.0`.

## Test Coverage

The new function have been fully covered by unit tests.

<details>

<summary>Test coverage details</summary>

| File                                   |  % Stmts | % Branch |  % Funcs |  % Lines |
|----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                             |   100.00 |    98.91 |   100.00 |   100.00 |
| ├─ CardPaymentProcessor.sol            |   100.00 |    99.28 |   100.00 |   100.00 |
| ├─ CardPaymentProcessorStorage.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CashbackDistributor.sol             |   100.00 |    97.73 |   100.00 |   100.00 |
| ├─ CashbackDistributorStorage.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ BlocklistableUpgradeable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RescuableUpgradeable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ StoragePlaceholder200.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICardPaymentCashback.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICardPaymentProcessor.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICashbackDistributor.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CashbackDistributorMock.sol         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/base/                  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ BlocklistableUpgradeableMock.sol    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RescuableUpgradeableMock.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/tokens/                |   100.00 |    50.00 |   100.00 |   100.00 |
| ├─ ERC20TokenMock.sol                  |   100.00 |    50.00 |   100.00 |   100.00 |
|----------------------------------------|----------|----------|----------|----------|
| All files                              |   100.00 |    98.83 |   100.00 |   100.00 |
|----------------------------------------|----------|----------|----------|----------|

</details>

