### PR TITLE
feat: new token flow on cashback revocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ node_modules
 
 # Environment variables
 .env
+
+.DS_Store

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": "hardhat/register",
+  "timeout": 40000,
+  "_": ["test/**/*.ts"]
+}

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1428,7 +1428,6 @@ contract CardPaymentProcessor is
             if (sponsor != address(0)) {
                 token.safeTransferFrom(cashOutAccount_, sponsor, operation.sponsorSentAmount);
             }
-            // token.safeTransferFrom(cashOutAccount_, address(this), operation.revokedCashbackAmount);
         }
 
         _revokeCashback(authorizationId, operation.revokedCashbackAmount);

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1399,7 +1399,7 @@ contract CardPaymentProcessor is
             revert InappropriateNewExtraPaymentAmount();
         }
 
-        RefundingOperation memory operation =   _defineRefundingOperation(refundAmount, newExtraAmount, payment);
+        RefundingOperation memory operation = _defineRefundingOperation(refundAmount, newExtraAmount, payment);
 
         payment.refundAmount = operation.newPaymentRefundAmount;
         payment.compensationAmount = operation.newCompensationAmount;

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1399,7 +1399,7 @@ contract CardPaymentProcessor is
             revert InappropriateNewExtraPaymentAmount();
         }
 
-        RefundingOperation memory operation = _defineRefundingOperation(refundAmount, newExtraAmount, payment);
+        RefundingOperation memory operation =   _defineRefundingOperation(refundAmount, newExtraAmount, payment);
 
         payment.refundAmount = operation.newPaymentRefundAmount;
         payment.compensationAmount = operation.newCompensationAmount;

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1522,11 +1522,9 @@ contract CardPaymentProcessor is
         uint256 paymentExtraAmountChange = oldPaymentExtraAmount - newPaymentExtraAmount;
         uint256 accountExtraAmountChange = oldAccountExtraAmount - newAccountExtraAmount;
         operation.accountSentAmount =
-            operation.newCompensationAmount -
-            operation.oldCompensationAmount -
-            newSponsorRefundAmount +
-            accountExtraAmountChange +
-            operation.revokedCashbackAmount;
+            operation.paymentRefundAmount -
+            operation.sponsorRefundAmount +
+            accountExtraAmountChange;
         operation.sponsorSentAmount =
             operation.sponsorRefundAmount +
             paymentExtraAmountChange -

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1352,7 +1352,7 @@ contract CardPaymentProcessor is
         uint256 paymentSumAmount = paymentBaseAmount + payment.extraAmount;
         (uint256 accountSumAmount, uint256 sponsorSumAmount) = _defineSumAmountParts(paymentSumAmount, subsidyLimit);
         uint256 paymentTotalAmount = paymentSumAmount - paymentRefundAmount;
-        uint256 accountSentAmount = accountSumAmount - (payment.compensationAmount - sponsorRefundAmount);
+        uint256 accountSentAmount = accountSumAmount - (paymentRefundAmount - sponsorRefundAmount);
         uint256 sponsorSentAmount = sponsorSumAmount - sponsorRefundAmount;
 
         CancelingOperation memory operation = CancelingOperation({
@@ -1360,7 +1360,7 @@ contract CardPaymentProcessor is
             accountSentAmount: accountSentAmount,
             sponsorSentAmount: sponsorSentAmount,
             totalSentAmount: accountSentAmount + sponsorSentAmount,
-            revokedCashbackAmount: paymentTotalAmount - accountSentAmount - sponsorSentAmount
+            revokedCashbackAmount: payment.compensationAmount - paymentRefundAmount
         });
 
         return operation;
@@ -1526,7 +1526,8 @@ contract CardPaymentProcessor is
             operation.newCompensationAmount -
             operation.oldCompensationAmount -
             newSponsorRefundAmount +
-            accountExtraAmountChange;
+            accountExtraAmountChange +
+            operation.revokedCashbackAmount;
         operation.sponsorSentAmount =
             operation.sponsorRefundAmount +
             paymentExtraAmountChange -

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1075,18 +1075,10 @@ contract CardPaymentProcessor is
             operation.paymentTotalAmountChange = oldPaymentSumAmount - newPaymentSumAmount;
             operation.sponsorBalanceChange = oldSponsorSumAmount - newSponsorSumAmount;
             operation.accountBalanceChange = oldAccountSumAmount - newAccountSumAmount;
-
-            if (operation.cashbackDecreased) {
-                operation.accountBalanceChange -= operation.cashbackAmountChange;
-            }
         } else {
             operation.paymentTotalAmountChange = newPaymentSumAmount - oldPaymentSumAmount;
             operation.sponsorBalanceChange = newSponsorSumAmount - oldSponsorSumAmount;
             operation.accountBalanceChange = newAccountSumAmount - oldAccountSumAmount;
-
-            if (operation.cashbackDecreased) {
-                operation.accountBalanceChange += operation.cashbackAmountChange;
-            }
         }
         return operation;
     }

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -1428,7 +1428,7 @@ contract CardPaymentProcessor is
             if (sponsor != address(0)) {
                 token.safeTransferFrom(cashOutAccount_, sponsor, operation.sponsorSentAmount);
             }
-            token.safeTransferFrom(cashOutAccount_, address(this), operation.revokedCashbackAmount);
+            // token.safeTransferFrom(cashOutAccount_, address(this), operation.revokedCashbackAmount);
         }
 
         _revokeCashback(authorizationId, operation.revokedCashbackAmount);

--- a/contracts/CashbackDistributor.sol
+++ b/contracts/CashbackDistributor.sol
@@ -49,7 +49,7 @@ contract CashbackDistributor is
         address recipient;
         address sender;
         uint256 nonce;
-        uint256 newAmount; // means different things in different functions
+        uint256 newAmount;
     }
 
     // ------------------ Constants ------------------------------- //
@@ -193,7 +193,6 @@ contract CashbackDistributor is
             recipient: cashback.recipient,
             sender: _msgSender(),
             nonce: nonce,
-            // in revoke cashback function newAmount means total revoked cashback ~~ cashback.revokedAmount
             newAmount: cashback.revokedAmount
         });
 
@@ -203,6 +202,8 @@ contract CashbackDistributor is
             revocationStatus = RevocationStatus.Inapplicable;
         } else if (amount > IERC20Upgradeable(context.token).balanceOf(context.recipient)) {
             revocationStatus = RevocationStatus.OutOfFunds;
+        } else if (amount > IERC20Upgradeable(context.token).allowance(context.recipient, address(this))) {
+            revocationStatus = RevocationStatus.OutOfAllowance;
         } else if (amount > cashback.amount - context.newAmount) {
             revocationStatus = RevocationStatus.OutOfBalance;
         } else {
@@ -217,7 +218,7 @@ contract CashbackDistributor is
             context.externalId,
             context.recipient,
             amount,
-            revocationStatus == RevocationStatus.Inapplicable ? 0 : cashback.amount - context.newAmount, // remaining cashback
+            revocationStatus == RevocationStatus.Inapplicable ? 0 : cashback.amount - context.newAmount, // totalAmount
             context.sender,
             context.nonce
         );
@@ -252,7 +253,6 @@ contract CashbackDistributor is
             recipient: cashback.recipient,
             sender: _msgSender(),
             nonce: nonce,
-            // in increase cashback function newAmount means total cashback ~~ cashback.amount
             newAmount: cashback.amount
         });
 

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -12,6 +12,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 2, 1);
+        return Version(1, 3, 0);
     }
 }

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -226,10 +226,18 @@ interface ICardPaymentProcessorPrimary is ICardPaymentProcessorTypes {
 
     /**
      * @dev Emitted when a payment is revoked.
+     *
+     * Legacy Notes:
+     *
+     * - Before v.1.3: The `sentAmount` parameter took the cashback into account and the formula was
+     *   `sentAmount = accountSumAmount - accountRefundAmount - cashbackAmount`. The new formula is:
+     *   `sentAmount = accountSumAmount - accountRefundAmount` and cashback is revoked separately by the
+     *   CashbackDistributor contract.
+     *
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
      * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      * @param account The account that made the payment.
-     * @param sentAmount The amount of tokens sent back to the account.
+     * @param sentAmount The amount of tokens sent back to the account before the cashback revocation if any.
      * @param clearedBalance The balance of cleared tokens of the account.
      * @param unclearedBalance The balance of uncleared tokens of the account.
      * @param wasPaymentCleared Whether the payment was cleared before revocation.
@@ -266,10 +274,15 @@ interface ICardPaymentProcessorPrimary is ICardPaymentProcessorTypes {
 
     /**
      * @dev Emitted when a payment is reversed.
+     *
+     * Legacy Notes:
+     *
+     * - Before v.1.3: See the same note for the {RevokePayment} event.
+     *
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
      * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      * @param account The account that made the payment.
-     * @param sentAmount The amount of tokens sent back to the account.
+     * @param sentAmount The amount of tokens sent back to the account before the cashback revocation if any.
      * @param clearedBalance The balance of cleared tokens of the account.
      * @param unclearedBalance The balance of uncleared tokens of the account.
      * @param wasPaymentCleared Whether the payment was cleared before reversal.
@@ -334,11 +347,21 @@ interface ICardPaymentProcessorPrimary is ICardPaymentProcessorTypes {
 
     /**
      * @dev Emitted when a payment is refunded.
+     *
+     * Legacy Notes:
+     *
+     * - Before v.1.3: The `sentAmount` parameter took the cashback into account and the formula was
+     *   `sentAmount = accountRefundAmountDiff - accountExtraAmountDiff - revokedCashbackAmount`. The new formula is:
+     *   `sentAmount = accountRefundAmountDiff - accountExtraAmountDiff` and cashback is revoked separately by the
+     *   CashbackDistributor contract.
+     *   In the formulas above: `accountRefundAmountDiff` = newAccountRefundAmount - oldAccountRefundAmount,
+     *   `accountExtraAmountDiff` = newAccountExtraAmount - oldAccountExtraAmount.
+     *
      * @param authorizationId The card transaction authorization ID from the off-chain card processing backend.
      * @param correlationId The ID that is correlated to this function call in the off-chain card processing backend.
      * @param account The account to be refunded.
      * @param refundAmount The amount of tokens refunded to the account.
-     * @param sentAmount The amount of tokens sent back to the account.
+     * @param sentAmount The amount of tokens sent back to the account before the cashback revocation if any.
      * @param status The status of the payment.
      */
     event RefundPayment(

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -247,6 +247,10 @@ interface ICashbackDistributorPrimary is ICashbackDistributorTypes {
      * This function is expected to be called by a limited number of accounts
      * that are allowed to execute cashback operations.
      *
+     * Legacy Notes:
+     *
+     * - Before v.1.3: The function transfers the underlying tokens from the caller to the contract.
+     *
      * Emits a {RevokeCashback} event if the cashback is successfully revoked.
      *
      * @param nonce The nonce of the cashback operation.

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -51,9 +51,7 @@ interface ICashbackDistributorTypes {
      * - Unknown = 0 --------- The operation has not been initiated (the default value).
      * - Success = 1 --------- The operation has been successfully executed.
      * - Inapplicable = 2 ---- The operation has been failed because the cashback does not have a relevant status.
-     * - OutOfFunds = 3 ------ The operation has been failed because the caller does not have enough tokens.
-     * - OutOfAllowance = 4 -- The operation has been failed because
-     *                         the caller does not have enough allowance for the contract.
+     * - OutOfFunds = 3 ------ The operation has been failed because the recipient does not have enough tokens.
      * - OutOfBalance = 5 ---- The operation has been failed because the revocation amount exceeds the cashback amount.
      */
     enum RevocationStatus {
@@ -61,7 +59,7 @@ interface ICashbackDistributorTypes {
         Success,
         Inapplicable,
         OutOfFunds,
-        OutOfAllowance,
+        _gap,
         OutOfBalance
     }
 

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -243,7 +243,7 @@ interface ICashbackDistributorPrimary is ICashbackDistributorTypes {
     /**
      * @dev Revokes a previously sent cashback.
      *
-     * Transfers the underlying tokens from the recipient to the contract.
+     * Transfers the underlying tokens from the initial cashback recipient to the contract.
      * This function is expected to be called by a limited number of accounts
      * that are allowed to execute cashback operations.
      *
@@ -258,7 +258,8 @@ interface ICashbackDistributorPrimary is ICashbackDistributorTypes {
     /**
      * @dev Increases a previously sent cashback.
      *
-     * Transfers the underlying tokens from the contract to the recipient if there are appropriate conditions.
+     * Transfers the underlying tokens from the contract to the initial cashback recipient
+     * if there are appropriate conditions.
      * This function is expected to be called by a limited number of accounts
      * that are allowed to execute cashback operations.
      *

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -51,7 +51,9 @@ interface ICashbackDistributorTypes {
      * - Unknown = 0 --------- The operation has not been initiated (the default value).
      * - Success = 1 --------- The operation has been successfully executed.
      * - Inapplicable = 2 ---- The operation has been failed because the cashback does not have a relevant status.
-     * - OutOfFunds = 3 ------ The operation has been failed because the recipient does not have enough tokens.
+     * - OutOfFunds = 3 ------ The operation has been failed because the caller does not have enough tokens.
+     * - OutOfAllowance = 4 -- The operation has been failed because
+     *                         the caller does not have enough allowance for the contract.
      * - OutOfBalance = 5 ---- The operation has been failed because the revocation amount exceeds the cashback amount.
      */
     enum RevocationStatus {
@@ -59,7 +61,7 @@ interface ICashbackDistributorTypes {
         Success,
         Inapplicable,
         OutOfFunds,
-        _gap,
+        OutOfAllowance,
         OutOfBalance
     }
 

--- a/contracts/interfaces/ICashbackDistributor.sol
+++ b/contracts/interfaces/ICashbackDistributor.sol
@@ -243,7 +243,7 @@ interface ICashbackDistributorPrimary is ICashbackDistributorTypes {
     /**
      * @dev Revokes a previously sent cashback.
      *
-     * Transfers the underlying tokens from the caller to the contract.
+     * Transfers the underlying tokens from the recipient to the contract.
      * This function is expected to be called by a limited number of accounts
      * that are allowed to execute cashback operations.
      *

--- a/contracts/mocks/CashbackDistributorMock.sol
+++ b/contracts/mocks/CashbackDistributorMock.sol
@@ -274,7 +274,7 @@ contract CashbackDistributorMock is ICashbackDistributor {
         success = revokeCashbackSuccessResult;
         emit RevokeCashbackMock(msg.sender, nonce, amount);
         if (success) {
-            IERC20Upgradeable(lastCashbackToken).transferFrom(msg.sender, address(this), amount);
+            IERC20Upgradeable(lastCashbackToken).transferFrom(lastCashbackRecipient, address(this), amount);
         }
     }
 

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -11,7 +11,6 @@ import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC2
  */
 contract ERC20TokenMock is ERC20Upgradeable {
     bool public mintResult;
-    mapping(address => bool) trustedAccounts;
 
     // ------------------ Initializers ---------------------------- //
 
@@ -38,16 +37,5 @@ contract ERC20TokenMock is ERC20Upgradeable {
     function mint(address account, uint256 amount) external returns (bool) {
         _mint(account, amount);
         return mintResult;
-    }
-
-    function allowance(address owner, address spender) public view override returns (uint256) {
-        if (trustedAccounts[spender]) {
-            return type(uint256).max;
-        }
-        return super.allowance(owner, spender);
-    }
-
-    function setTrustedAccount(address account, bool isTrusted) external {
-        trustedAccounts[account] = isTrusted;
     }
 }

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -11,6 +11,7 @@ import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC2
  */
 contract ERC20TokenMock is ERC20Upgradeable {
     bool public mintResult;
+    mapping(address => bool) trustedAccounts;
 
     // ------------------ Initializers ---------------------------- //
 
@@ -37,5 +38,16 @@ contract ERC20TokenMock is ERC20Upgradeable {
     function mint(address account, uint256 amount) external returns (bool) {
         _mint(account, amount);
         return mintResult;
+    }
+
+    function allowance(address owner, address spender) public view override returns (uint256) {
+        if (trustedAccounts[spender]) {
+            return type(uint256).max;
+        }
+        return super.allowance(owner, spender);
+    }
+
+    function setTrustedAccount(address account, bool isTrusted) external {
+        trustedAccounts[account] = isTrusted;
     }
 }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1410,6 +1410,10 @@ class TestContext {
         account.address,
         getAddress(this.cardPaymentProcessorShell.contract)
       );
+
+      await proveTx(
+        connect(this.tokenMock, account).approve(getAddress(this.cashbackDistributorMockShell.contract), MAX_UINT256)
+      );
       if (allowance < MAX_UINT256) {
         await proveTx(
           connect(this.tokenMock, account).approve(getAddress(this.cardPaymentProcessorShell.contract), MAX_UINT256)

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -353,7 +353,6 @@ class CardPaymentProcessorModel {
     operation.newExtraAmount = newExtraAmount;
     this.#checkPaymentRefunding(operation, payment);
     this.#definePaymentRefundingOperation(operation, payment);
-    console.log(operation, payment);
     return this.#registerPaymentRefundingOperation(operation, payment);
   }
 
@@ -618,8 +617,7 @@ class CardPaymentProcessorModel {
         }
         operation.userBalanceChange = -accountAmountDiff + operation.cashbackActualChange;
         operation.sponsorBalanceChange = -sponsorAmountDiff;
-        operation.cardPaymentProcessorBalanceChange =
-          amountDiff; // - (operation.cashbackRequestedChange - operation.cashbackActualChange);
+        operation.cardPaymentProcessorBalanceChange = amountDiff;
         operation.compensationAmountChange = operation.cashbackRequestedChange;
       }
     }
@@ -732,7 +730,6 @@ class CardPaymentProcessorModel {
       payment.baseAmount,
       payment.subsidyLimit
     );
-
     operation.sponsorBalanceChange =
       amountParts.sponsorBaseAmount + amountParts.sponsorExtraAmount - refundParts.sponsorRefundAmount;
     if (payment.cashbackEnabled) {
@@ -747,7 +744,6 @@ class CardPaymentProcessorModel {
     }
     operation.cardPaymentProcessorBalanceChange =
       -(payment.baseAmount + payment.extraAmount - payment.refundAmount);
-    // - (operation.cashbackRequestedChange - operation.cashbackActualChange);
 
     operation.userBalanceChange =
       amountParts.accountBaseAmount +
@@ -876,9 +872,6 @@ class CardPaymentProcessorModel {
     }
 
     if (operation.paymentStatus === PaymentStatus.Confirmed) {
-      // operation.cardPaymentProcessorBalanceChange = -(
-      //   operation.cashbackRequestedChange - operation.cashbackActualChange
-      // );
       operation.cashOutAccountBalanceChange = -(
         operation.refundAmountChange +
         (operation.oldExtraAmount - operation.newExtraAmount)
@@ -886,10 +879,8 @@ class CardPaymentProcessorModel {
     } else {
       operation.cardPaymentProcessorBalanceChange =
         -(operation.refundAmountChange + (operation.oldExtraAmount - operation.newExtraAmount));
-      // - (operation.cashbackRequestedChange - operation.cashbackActualChange);
     }
     operation.totalAmount = payment.baseAmount + operation.newExtraAmount - newPaymentRefundAmount;
-    // console.log(operation.totalAmount, payment.baseAmount, operation.newExtraAmount, newPaymentRefundAmount);
     operation.compensationAmountChange = operation.refundAmountChange + operation.cashbackRequestedChange;
     operation.sponsorRefundAmountChange = sponsorRefundAmount;
   }
@@ -910,7 +901,6 @@ class CardPaymentProcessorModel {
     } else {
       this.#totalBalance += -(operation.cashbackRequestedChange - operation.cashbackActualChange);
     }
-    console.log(this.#totalBalance, operation.cardPaymentProcessorBalanceChange);
     return this.#paymentOperations.push(operation) - 1;
   }
 
@@ -1697,7 +1687,7 @@ class TestContext {
     const balanceChangePerAccount: Map<HardhatEthersSigner, number> = this.#getBalanceChangePerAccount(operations);
     const accounts: HardhatEthersSigner[] = Array.from(balanceChangePerAccount.keys());
     const accountBalanceChanges: number[] = accounts.map(user => balanceChangePerAccount.get(user) ?? 0);
-    console.log(operations);
+
     await expect(tx).to.changeTokenBalances(
       this.tokenMock,
       [
@@ -2047,7 +2037,6 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     const { cardPaymentProcessor, tokenMock } = await deployTokenMockAndCardPaymentProcessor();
     const { cashbackDistributorMock, cashbackDistributorMockConfig } = await deployCashbackDistributorMock();
 
-    await proveTx(tokenMock.setTrustedAccount(getAddress(cashbackDistributorMock), true));
     await proveTx(cardPaymentProcessor.grantRole(GRANTOR_ROLE, deployer.address));
     await proveTx(cardPaymentProcessor.grantRole(EXECUTOR_ROLE, executor.address));
     await proveTx(cardPaymentProcessor.setCashbackDistributor(getAddress(cashbackDistributorMock)));
@@ -2079,8 +2068,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     for (let i = 0; i < numberOfPayments; ++i) {
       const payment: TestPayment = {
         account: i % 2 > 0 ? user1 : user2,
-        baseAmount: Math.floor(100 * DIGITS_COEF + i * 100 * DIGITS_COEF),
-        extraAmount: Math.floor(100 * DIGITS_COEF + i * 100 * DIGITS_COEF),
+        baseAmount: Math.floor(123.456789 * DIGITS_COEF + i * 123.456789 * DIGITS_COEF),
+        extraAmount: Math.floor(123.456789 * DIGITS_COEF + i * 123.456789 * DIGITS_COEF),
         authorizationId: ethers.toBeHex(123 + i * 123, BYTES16_LENGTH),
         correlationId: ethers.toBeHex(345 + i * 345, BYTES16_LENGTH),
         parentTxHash: ethers.toBeHex(1 + i, BYTES32_LENGTH)

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1906,8 +1906,8 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const CASHBACK_NONCE = 111222333;
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 2,
-    patch: 1
+    minor: 3,
+    patch: 0
   };
 
   // Error messages of the library contracts

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -2041,6 +2041,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
     const { cardPaymentProcessor, tokenMock } = await deployTokenMockAndCardPaymentProcessor();
     const { cashbackDistributorMock, cashbackDistributorMockConfig } = await deployCashbackDistributorMock();
 
+    await proveTx(tokenMock.setTrustedAccount(getAddress(cashbackDistributorMock), true));
     await proveTx(cardPaymentProcessor.grantRole(GRANTOR_ROLE, deployer.address));
     await proveTx(cardPaymentProcessor.grantRole(EXECUTOR_ROLE, executor.address));
     await proveTx(cardPaymentProcessor.setCashbackDistributor(getAddress(cashbackDistributorMock)));
@@ -2969,7 +2970,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
       describe("Not subsidized. And if the new base amount is", async () => {
         describe("Less than the initial one. And if the extra amount is", async () => {
           describe("The same as the initial one. And if cashback sending is", async () => {
-            it("Enabled and cashback revoking is executed successfully", async () => {
+            it.only("Enabled and cashback revoking is executed successfully", async () => {
               await checkUpdatingForNonSubsidizedPayment(
                 NewBasePaymentAmountType.Less,
                 NewExtraPaymentAmountType.Same,

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -899,7 +899,7 @@ class CardPaymentProcessorModel {
       this.#totalClearedBalance += balanceChange;
       this.#totalBalance += operation.cardPaymentProcessorBalanceChange;
     } else {
-      this.#totalBalance += -(operation.cashbackRequestedChange - operation.cashbackActualChange);
+      // operation.paymentStatus == PaymentStatus.Confirmed
     }
     return this.#paymentOperations.push(operation) - 1;
   }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -752,7 +752,7 @@ class CardPaymentProcessorModel {
     operation.userBalanceChange =
       amountParts.accountBaseAmount +
       amountParts.accountExtraAmount -
-      payment.refundAmount +
+      refundParts.accountRefundAmount +
       operation.cashbackActualChange;
   }
 
@@ -1664,7 +1664,7 @@ class TestContext {
         checkEventField("correlationId", operation.correlationId),
         checkEventField("account", operation.account.address),
         checkEventField("refundAmount", operation.refundAmountChange),
-        checkEventField("sentAmount", -operation.cardPaymentProcessorBalanceChange),
+        checkEventField("sentAmount", -(operation.cashOutAccountBalanceChange + operation.cardPaymentProcessorBalanceChange)),
         checkEventField("status", operation.paymentStatus)
       );
 

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1658,7 +1658,10 @@ class TestContext {
         checkEventField("correlationId", operation.correlationId),
         checkEventField("account", operation.account.address),
         checkEventField("refundAmount", operation.refundAmountChange),
-        checkEventField("sentAmount", -(operation.cashOutAccountBalanceChange + operation.cardPaymentProcessorBalanceChange)),
+        checkEventField(
+          "sentAmount",
+          -(operation.cashOutAccountBalanceChange + operation.cardPaymentProcessorBalanceChange)
+        ),
         checkEventField("status", operation.paymentStatus)
       );
 

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -938,7 +938,7 @@ describe("Contract 'CashbackDistributor'", async () => {
           await checkRevoking(RevocationStatus.OutOfFunds, context);
         });
 
-        it("The recipient has not enough tokens and the initial sending operation is partially successful", async () => {
+        it("The recipient has not enough tokens and the initial sending op is partially successful", async () => {
           const context = await beforeSendingCashback({ cashbackRequestedAmount: MAX_CASHBACK_FOR_PERIOD + 1 });
           const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
           await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Partial);

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -949,19 +949,6 @@ describe("Contract 'CashbackDistributor'", async () => {
           await checkRevoking(RevocationStatus.OutOfFunds, context);
         });
 
-        // it("The cashback distributor has not enough allowance from the caller", async () => {
-        //   const context = await beforeSendingCashback();
-        //   const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;
-        //   await sendCashbacks(cashbackDistributor, [cashback], CashbackStatus.Success);
-        //   cashback.revokedAmount = Math.floor(cashback.requestedAmount * 0.1);
-        //   await proveTx(cashback.token.mint(distributor.address, cashback.revokedAmount));
-        //   await proveTx(connect(cashback.token, distributor).approve(
-        //     getAddress(cashbackDistributor),
-        //     (cashback.revokedAmount ?? 0) - 1
-        //   ));
-        //   await checkRevoking(RevocationStatus.OutOfAllowance, context);
-        // });
-
         it("The initial cashback amount is less than revocation amount", async () => {
           const context = await beforeSendingCashback();
           const { fixture: { cashbackDistributor }, cashbacks: [cashback] } = context;

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -177,8 +177,8 @@ describe("Contract 'CashbackDistributor'", async () => {
   const MAX_CASHBACK_FOR_PERIOD = 300 * 10 ** 6;
   const EXPECTED_VERSION: Version = {
     major: 1,
-    minor: 2,
-    patch: 1
+    minor: 3,
+    patch: 0
   };
 
   // Events of the contract under test

--- a/test/CashbackDistributor.test.ts
+++ b/test/CashbackDistributor.test.ts
@@ -255,6 +255,10 @@ describe("Contract 'CashbackDistributor'", async () => {
     const tokenMock1 = await deployTokenMock("1");
     const tokenMock2 = await deployTokenMock("2");
 
+    await proveTx(connect(tokenMock1, deployer).approve(getAddress(cashbackDistributor), MAX_UINT256));
+    await proveTx(connect(tokenMock2, deployer).approve(getAddress(cashbackDistributor), MAX_UINT256));
+    await proveTx(connect(tokenMock1, user).approve(getAddress(cashbackDistributor), MAX_UINT256));
+    await proveTx(connect(tokenMock2, user).approve(getAddress(cashbackDistributor), MAX_UINT256));
     await proveTx(cashbackDistributor.grantRole(GRANTOR_ROLE, deployer.address));
     await proveTx(cashbackDistributor.grantRole(BLOCKLISTER_ROLE, deployer.address));
     await proveTx(cashbackDistributor.grantRole(DISTRIBUTOR_ROLE, distributor.address));


### PR DESCRIPTION
Closes https://github.com/cloudwalk/product-smart-contracts/issues/211

## Main changes

1. Changed token flow related to cashback. Now the `CashbackDistributor`(CD) smart contract sends cashback directly to user and claws it from user if needed.

2. When cashback is revoked CD claws tokens directly from cashback recipient, instead of `msg.sender`.

2. The `CardPaymentProcessor` (CPP) smart contract and the cash-out account (COA) now sends full payment refund to user, without applying cashback to refund amount.

3. The calculation logic for the `sentAmount` parameter of the following CPP events has been changed: `RevokePayment`, `ReversePayment`, `RefundPayment`. See details in the appropriate section below.

4. Fixed and corrected all tests to support new token flow.

## Token Flow Scenarios

### Regular cashback payment

No changes.

1. Account → (payment amount) → CPP
2. CD → (cashback amount) → Account

### **Increase in Payment**

No changes.

1. Account → (payment increase) → CPP
2. CD → (cashback increase) → Account

### Decrease in Cashback After `Reversal` or `Partial Reversal`
**BEFORE:**
1. CPP → (payment decrease - cashback decrease) → Account
2. CPP → (cashback decrease) → CD

**AFTER**
1. CPP → (payment decrease) → Account
2. Account → (cashback decrease) → CD

### Decrease in `Refund` of `Confirmed` transaction
**BEFORE:**
1. COA → (payment decrease - cashback decrease) → Account
2. COA → (cashback decrease) → CPP
3. CPP → (cashback decrease) → CD

**AFTER**
1. COA → (payment decrease) → Account
3. Account → (cashback decrease) → CD



Main difference is in that case - in any payment amount decrease events - we revoke cashback directly from USER account **after** returning to him **full** payment decrease amount.

Balances after any transaction are the same as before the change.

## Event Parameter Changes

Changed event parameters:
* CardPaymentProcessor->`RevokePayment(...other, uint256 sentAmount ...other )`
* CardPaymentProcessor->`ReversePayment(...other, uint256 sentAmount ...other )`
* CardPaymentProcessor->`RefundPayment(...other, uint256 sentAmount ...other )`

`uint256 sentAmount` in that events now does not include cashback correction. Now it is greater then before.

## Versioning

The version of contracts has been bumped to **1.3.0**